### PR TITLE
Change string formatter to use currency designator

### DIFF
--- a/CSharp/AboutStrings.cs
+++ b/CSharp/AboutStrings.cs
@@ -169,7 +169,7 @@ broken line";
 		[Koan(17)]
 		public void CurrencyDesignatorsCanBeAdded()
 		{
-			var str = string.Format("{0:n}", 123456);
+			var str = string.Format("{0:C}", 123456);
 			Assert.Equal(FILL_ME_IN, str);
 		}
 


### PR DESCRIPTION
Change formatter to use 'C' designation for currency instead of 'n' for number in AboutStrings.cs CurrencyDesignatorCanBeAdded koan.
